### PR TITLE
update/wag-20/exception-filter

### DIFF
--- a/src/exception/error-code.enum.ts
+++ b/src/exception/error-code.enum.ts
@@ -1,0 +1,4 @@
+export enum ErrorCode {
+    UNKNOWN_F001 = "UNKNOWN-F001",
+    DEFAULT_F001 = "DEFAULT_F001"
+}

--- a/src/exception/error-data.ts
+++ b/src/exception/error-data.ts
@@ -1,9 +1,12 @@
 import {
     ErrorObject,
 } from "./error-object";
+import {
+    ErrorCode,
+} from "./error-code.enum";
 
 export interface ErrorData {
-    // TODO: ErrorCode 정책 정하면 추가
+    code: ErrorCode,
     data: ErrorObject,
     timestamp: string
 }

--- a/src/exception/error-type.ts
+++ b/src/exception/error-type.ts
@@ -1,0 +1,17 @@
+import {
+    ErrorCode,
+} from "./error-code.enum";
+
+export type ErrorResponseType = string | CustomErrorResponseType | DefaultErrorResponseType
+export type CustomErrorResponseType = { message: string, errorCode: ErrorCode }
+export type DefaultErrorResponseType = { message: string, status: number }
+
+export function isCustomErrorResponseType(response: ErrorResponseType)
+    : response is { message: string, errorCode: ErrorCode } {
+    return typeof response === "object" && "message" in response && "errorCode" in response;
+}
+
+export function isDefaultErrorResponseType(response: ErrorResponseType)
+    : response is { message: string, status: number } {
+    return typeof response === "object" && "message" in response && "status" in response;
+}

--- a/src/exception/http/not-found.exception.ts
+++ b/src/exception/http/not-found.exception.ts
@@ -1,9 +1,15 @@
 import {
     HttpException, HttpStatus,
 } from "@nestjs/common";
+import {
+    ErrorCode,
+} from "../error-code.enum";
 
 export class NotFoundException extends HttpException {
-    constructor(value: string) {
-        super(`${value} Not Found`, HttpStatus.NOT_FOUND);
+    constructor(value: string, errorCode: ErrorCode) {
+        super({
+            message: `${value} Not Found`,
+            errorCode: errorCode,
+        }, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -2,8 +2,7 @@ import {
     Request, Response,
 } from "express";
 import {
-    ArgumentsHost,
-    Catch, ExceptionFilter, HttpException, HttpStatus, Logger,
+    ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger,
 } from "@nestjs/common";
 import {
     ErrorData,
@@ -11,8 +10,15 @@ import {
 import {
     ErrorObject,
 } from "../exception/error-object";
+import {
+    ErrorResponseType, isCustomErrorResponseType, isDefaultErrorResponseType,
+} from "../exception/error-type";
+import {
+    ErrorCode,
+} from "../exception/error-code.enum";
 
 @Catch(HttpException)
+
 export class HttpExceptionFilter implements ExceptionFilter {
     private readonly logger = new Logger(HttpExceptionFilter.name);
 
@@ -22,11 +28,19 @@ export class HttpExceptionFilter implements ExceptionFilter {
         const request = ctx.getRequest<Request>();
         const status = exception.getStatus();
 
-        let errorMessage = exception.getResponse() as
-            | string
-            | { message: string, statusCode: number };
-        if (typeof errorMessage === "object") {
-            errorMessage = errorMessage.message;
+        const errorResponse = exception.getResponse() as ErrorResponseType;
+        let errorMessage: string;
+        let code: ErrorCode;
+
+        if (isCustomErrorResponseType(errorResponse)) {
+            errorMessage = errorResponse.message;
+            code=errorResponse.errorCode;
+        } else if (isDefaultErrorResponseType(errorResponse)) {
+            errorMessage = errorResponse.message;
+            code= ErrorCode.DEFAULT_F001;
+        } else {
+            errorMessage = errorResponse;
+            code= ErrorCode.UNKNOWN_F001;
         }
 
         this.logger.error(
@@ -40,6 +54,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
             error: HttpStatus[status],
         };
         const errorData: ErrorData = {
+            code: code,
             data: errorObject,
             timestamp: new Date().toISOString(),
         };

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -34,15 +34,14 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
         if (isCustomErrorResponseType(errorResponse)) {
             errorMessage = errorResponse.message;
-            code=errorResponse.errorCode;
+            code = errorResponse.errorCode;
         } else if (isDefaultErrorResponseType(errorResponse)) {
             errorMessage = errorResponse.message;
-            code= ErrorCode.DEFAULT_F001;
+            code = ErrorCode.DEFAULT_F001;
         } else {
             errorMessage = errorResponse;
-            code= ErrorCode.UNKNOWN_F001;
+            code = ErrorCode.UNKNOWN_F001;
         }
-
         this.logger.error(
             `Error Occur ${request.url} ${request.method}, errorMessage: ${JSON.stringify(errorMessage, null, 2)}`,
         );

--- a/src/member/member.entity.ts
+++ b/src/member/member.entity.ts
@@ -3,10 +3,10 @@ import {
 } from "@prisma/client";
 
 export class MemberEntity implements Member {
-    constructor(private id: bigint,
-                private email: string,
-                private nickname: string,
-                private password: string,
-                private profile: string) {
+    constructor(readonly id: bigint,
+                readonly email: string,
+                readonly nickname: string,
+                readonly password: string,
+                readonly profile: string) {
     }
 }


### PR DESCRIPTION
# 작업 분류
- [x] 기능 변경 (update)

# 작업 내용 요약
exception handler를 frontend가 사용할 수 있는 error code를 포함하는 형태로 변경

# 코드 리뷰 참고 사항
exception Filter 사용에 대한 간단한 설명은
service에서 error catch (우리가 만든 exception) -> exception filter로 가서 예외 응답 객체로 변환해서 반환
exception 형태는 http-exception을 감싸서 status에 따른 exception을 만들고, 그걸 다시 감싸서 우리가 쓸 exception으로 만듦

# 관련 자료
[지라 티켓](https://hb-wisoft.atlassian.net/browse/WAG-20)
