### PR TITLE
Feature/WAG-34/checkDuplicateEmail

### DIFF
--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -32,6 +32,8 @@ import CheckDuplicateNicknameResponseDto from "./dto/res/check-duplicate-nicknam
 import {
     ApiCustomResponseDecorator,
 } from "../../util/decorators/api-custom-response.decorator";
+import CheckDuplicateEmailParamsDto from "./dto/req/check-duplicate-email.params.dto";
+import CheckDuplicateEmailResponseDto from "./dto/res/check-duplicate-email.response.dto";
 
 @ApiTags("auth")
 @Controller("/auth")
@@ -118,4 +120,17 @@ export default class AuthController {
         );
     }
 
+    @ApiOperation({
+        summary: "이메일 중복 확인 API",
+        description: "회원가입 절차중 이메일은 중복되어서는 안되기 때문에, 사용하고자 하는 이메일의 중복을 확인한다.",
+    })
+    @ApiCustomResponseDecorator(CheckDuplicateEmailResponseDto)
+    @Get("/emails")
+    async checkDuplicateEmail(@Query() params: CheckDuplicateEmailParamsDto) {
+        const result = await this.authService.checkDuplicateEmail(params);
+
+        return new CustomResponse<CheckDuplicateEmailResponseDto>(
+            ResponseCode.AUTH_S005, result
+        );
+    }
 }

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -23,6 +23,8 @@ import Redis from "ioredis";
 import InvalidEmailException from "../../exception/invalid-email.exception";
 import CheckDuplicateNicknameParamsDto from "./dto/req/check-duplicate-nickname.params.dto";
 import CheckDuplicateNicknameResponseDto from "./dto/res/check-duplicate-nickname.response.dto";
+import CheckDuplicateEmailParamsDto from "./dto/req/check-duplicate-email.params.dto";
+import CheckDuplicateEmailResponseDto from "./dto/res/check-duplicate-email.response.dto";
 
 type ExistsMember = Member | null;
 
@@ -83,4 +85,15 @@ export default class AuthService {
         return new CheckDuplicateNicknameResponseDto(!!memberByNickname);
     }
 
+    async checkDuplicateEmail(
+        paramsDto: CheckDuplicateEmailParamsDto
+    ): Promise<CheckDuplicateEmailResponseDto> {
+        const memberByEmail: ExistsMember = await this.prisma.member.findUnique({
+            where: {
+                email: paramsDto.email,
+            },
+        });
+
+        return new CheckDuplicateEmailResponseDto(!!memberByEmail);
+    }
 }

--- a/src/domain/auth/dto/req/check-duplicate-email.params.dto.ts
+++ b/src/domain/auth/dto/req/check-duplicate-email.params.dto.ts
@@ -1,0 +1,20 @@
+import {
+    ApiProperty,
+} from "@nestjs/swagger";
+import {
+    IsEmail,
+} from "class-validator";
+
+export default class CheckDuplicateEmailParamsDto {
+    @ApiProperty({
+        type: String,
+        description: "중복 확인할 이메일 정보",
+        required: true,
+        example: "test123@naver.com",
+    })
+    @IsEmail({},{
+        message: "이메일은 비어있으면 안되며, 문자열 형식이어야 합니다.",
+    })
+    readonly email: string;
+
+}

--- a/src/domain/auth/dto/req/signup.request.dto.ts
+++ b/src/domain/auth/dto/req/signup.request.dto.ts
@@ -1,5 +1,5 @@
 import {
-    IsEmail, IsNotEmpty, IsString, IsUrl, Length, Matches,
+    IsEmail, IsNotEmpty, IsString, IsUrl, Matches,
 } from "class-validator";
 import {
     ApiProperty,
@@ -12,14 +12,8 @@ export default class SignupRequestDto {
         required: true,
         example: "test123@naver.com",
     })
-    @IsNotEmpty({
-        message: "이메일은 비어있으면 안됩니다.",
-    })
-    @IsString({
-        message: "이메일은 문자열이어야 합니다.",
-    })
     @IsEmail({}, {
-        message: "이메일 형식과 맞지 않습니다.",
+        message: "이메일은 비어있으면 안되며, 문자열 형식과 맞아야 합니다.",
     })
     readonly email: string;
 

--- a/src/domain/auth/dto/res/check-duplicate-email.response.dto.ts
+++ b/src/domain/auth/dto/res/check-duplicate-email.response.dto.ts
@@ -1,0 +1,17 @@
+import {
+    ApiProperty,
+} from "@nestjs/swagger";
+
+export default class CheckDuplicateEmailResponseDto {
+    @ApiProperty({
+        type: Boolean,
+        description: "중복 확인한 이메일에 대한 결과",
+        required: true,
+        example: true,
+    })
+    readonly result: boolean;
+
+    constructor(result: boolean) {
+        this.result = result;
+    }
+}

--- a/src/response/response-code.enum.ts
+++ b/src/response/response-code.enum.ts
@@ -10,6 +10,7 @@ export enum ResponseCode {
     AUTH_S002 = "AUTH-S002",
     AUTH_S003 = "AUTH-S003",
     AUTH_S004 = "AUTH-S004",
+    AUTH_S005 = "AUTH-S005",
     FILE_S001 = "FILE-S001",
 
 }


### PR DESCRIPTION
# 작업 분류
<!--이 PR에서 작업한 항목을 모두 체크 -->
- [x] 기능 추가 (feat)
- [ ] 기능 변경 (update)
- [x] 버그 수정 (fix)
- [ ] 테스트 코드 작성 (test)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (chore)
- [ ] 기타 사소한 수정 (docs)

<br>

# 작업 내용 요약
- 이메일 중복 확인 API 구현
- `@IsEmail()` 데코레이터는 `@IsNotEmpty()` 와 `@IsString()` 검증을 포함하므로 `@IsEmail() `만 사용해도 충분하기 때문에, `@IsEmail()` 사용
- 이메일 중복 확인 성공시 응답 코드 추가

<br>

# 코드 리뷰 참고 사항
`@IsEmail()` 데코레이터만 사용해도 충분하기 때문에, 기존에 `signup.request.dto.ts` 도 함께 수정했습니다.
추가 수정사항이 있으면 리뷰 남겨주세요 !

<br>

# 관련 자료
[Jira](https://hb-wisoft.atlassian.net/browse/WAG-34)

<br>