### PR TITLE
feature/WAG-73/leaveChatRoom

### DIFF
--- a/src/domain/chat-room/chat-room.controller.ts
+++ b/src/domain/chat-room/chat-room.controller.ts
@@ -1,5 +1,5 @@
 import {
-    Body, Controller, Get, HttpCode, HttpStatus, Logger, Post, Query, UseGuards,
+    Body, Controller, Delete, Get, HttpCode, HttpStatus, Logger, Param, Post, Query, UseGuards,
 } from "@nestjs/common";
 import {
     ChatRoomService,
@@ -32,6 +32,12 @@ import {
 import GetChatRoomQueryPipe from "./pipe/get-chat-room-query.pipe";
 import GetChatRoomQueryDto from "./dto/request/get-chat-room.query.dto";
 import GetChatRoomListResponseDto from "./dto/response/get-chat-room-list.response.dto";
+import {
+    LeaveChatRoomResponseDto,
+} from "./dto/response/leave-chat-room.response.dto";
+import {
+    BigIntPipe,
+} from "./pipe/bigint.pipe";
 
 @ApiTags("ChatRoom")
 @UseGuards(JwtGuard)
@@ -50,7 +56,7 @@ export class ChatRoomController {
     @ApiCustomResponseDecorator(CreateChatRoomResponseDto)
     @HttpCode(HttpStatus.CREATED)
     @Post()
-    async createCharRoom(@Body() createChatRoomDto: CreateChatRoomRequestDto, @GetMember() member: Member)
+    async createChatRoom(@Body() createChatRoomDto: CreateChatRoomRequestDto, @GetMember() member: Member)
         : Promise<CustomResponse<CreateChatRoomResponseDto>> {
         this.logger.log("[createCharRoom] start");
         const result = await this.chatRoomService.createChatRoom(createChatRoomDto, member);
@@ -78,6 +84,23 @@ export class ChatRoomController {
 
         return new CustomResponse(
             ResponseStatus.CHAT_ROOM_S002, result
+        );
+    }
+
+    @ApiOperation({
+        summary: "채팅방 나가기, 삭제 API",
+        description: "채팅방 id를 기반으로 본인이 채팅방에서 나갈 수 있다.",
+    })
+    @ApiCustomResponseDecorator(LeaveChatRoomResponseDto)
+    @HttpCode(HttpStatus.OK)
+    @Delete(":id")
+    async leaveChatRoom(@Param("id", BigIntPipe) id: bigint, @GetMember() member: Member) {
+        this.logger.log("[leaveChatRoom] start");
+        const result = await this.chatRoomService.leaveChatRoom(id, member);
+        this.logger.log("[leaveChatRoom] finish");
+
+        return new CustomResponse(
+            ResponseStatus.CHAT_ROOM_S003, result
         );
     }
 

--- a/src/domain/chat-room/dto/response/leave-chat-room.response.dto.ts
+++ b/src/domain/chat-room/dto/response/leave-chat-room.response.dto.ts
@@ -1,0 +1,13 @@
+import {
+    ApiProperty,
+} from "@nestjs/swagger";
+
+export class LeaveChatRoomResponseDto {
+    @ApiProperty({
+        type: String,
+        description: "Leave Message",
+        example: "채팅방에서 나갔습니다.",
+    })
+    readonly message: string;
+
+}

--- a/src/domain/chat-room/pipe/bigint.pipe.ts
+++ b/src/domain/chat-room/pipe/bigint.pipe.ts
@@ -1,0 +1,16 @@
+import InvalidParamsException from "../../../exception/invalid-params.exception";
+import {
+    Injectable, PipeTransform,
+} from "@nestjs/common";
+
+@Injectable()
+export class BigIntPipe implements PipeTransform {
+    transform(value: string) {
+        const result = BigInt(value);
+        if (isNaN(Number(result))) {
+            throw new InvalidParamsException();
+        }
+
+        return result;
+    }
+}

--- a/src/domain/chat-room/pipe/bigint.pipe.ts
+++ b/src/domain/chat-room/pipe/bigint.pipe.ts
@@ -6,11 +6,10 @@ import {
 @Injectable()
 export class BigIntPipe implements PipeTransform {
     transform(value: string) {
-        const result = BigInt(value);
-        if (isNaN(Number(result))) {
+        try {
+            return BigInt(value);
+        } catch (e) {
             throw new InvalidParamsException();
         }
-
-        return result;
     }
 }

--- a/src/exception/chat-room-not-found.exception.ts
+++ b/src/exception/chat-room-not-found.exception.ts
@@ -1,0 +1,13 @@
+import {
+    NotFoundException,
+} from "./http/not-found.exception";
+import {
+    ResponseStatusType,
+} from "../response/response-status";
+
+export class ChatRoomNotFoundException extends NotFoundException {
+    constructor(errorCode: ResponseStatusType) {
+        super("Not Found Chat Room", errorCode);
+    }
+
+}

--- a/src/exception/leave-chat-room-fail.exception.ts
+++ b/src/exception/leave-chat-room-fail.exception.ts
@@ -1,0 +1,12 @@
+import {
+    BadRequestException,
+} from "./http/bad-request.exception";
+import {
+    ResponseStatusType,
+} from "../response/response-status";
+
+export class LeaveChatRoomFailException extends BadRequestException {
+    constructor(errorCode: ResponseStatusType) {
+        super("Leave Chat Room Fail", errorCode);
+    }
+}

--- a/src/exception/member-not-found.exception.ts
+++ b/src/exception/member-not-found.exception.ts
@@ -1,0 +1,12 @@
+import {
+    NotFoundException,
+} from "./http/not-found.exception";
+import {
+    ResponseStatusType,
+} from "../response/response-status";
+
+export class MemberNotFoundException extends NotFoundException {
+    constructor(errorCode: ResponseStatusType) {
+        super("Not Found Member", errorCode);
+    }
+}

--- a/src/response/response-status.ts
+++ b/src/response/response-status.ts
@@ -24,8 +24,12 @@ export const ResponseStatus = {
     FILE_S001: createResponseStatus("FILE_S001", "POST /files"),
     CHAT_ROOM_F001: createResponseStatus("CHAT_ROOM_F001", "Prisma Error"),
     CHAT_ROOM_F002: createResponseStatus("CHAT_ROOM_F002", "Invalid Query Params"),
+    CHAT_ROOM_F003: createResponseStatus("CHAT_ROOM_F003", "Not found chatroom"),
+    CHAT_ROOM_F004: createResponseStatus("CHAT_ROOM_F004", "Not found member in chatroom"),
+    CHAT_ROOM_F005: createResponseStatus("CHAT_ROOM_F005", "Manager doesn't leave chatroom until only one left"),
     CHAT_ROOM_S001: createResponseStatus("CHAT_ROOM_S001", "POST /chat-rooms"),
     CHAT_ROOM_S002: createResponseStatus("CHAT_ROOM_S002", "GET /chat-rooms"),
+    CHAT_ROOM_S003: createResponseStatus("CHAT_ROOM_S003", "DELETE /chat-rooms"),
 } as const;
 export type ResponseStatusType = {
     code: string,

--- a/test/e2e/auth/chat-room.e2e-spec.ts
+++ b/test/e2e/auth/chat-room.e2e-spec.ts
@@ -470,7 +470,7 @@ describe("ChatRoom Test (e2e)", () => {
                     });
 
                     describe("혼자 남지 않은 경우,", () => {
-                        it("채팅방을 나가고, 채팅방도 삭제해야 한다. ", async () => {
+                        it("혼자 남지 않으면 채팅방을 나갈 수 없는 예외를 발생시켜야 한다. ", async () => {
                             // given
                             const currentPassword = generateRandomPasswordFunction();
                             const encryptedPassword = await bcrypt.hash(currentPassword, await bcrypt.genSalt());


### PR DESCRIPTION
# 작업 분류
<!--이 PR에서 작업한 항목을 모두 체크 -->
- [x] 기능 추가 (feat)
- [x] 테스트 코드 작성 (test)

<br>

# 작업 내용 요약
<!--
ex)
prisma v5 update.
hook이 v5부터는 해당 위치에서 사용되지 않아서 제거
-->
* 채팅방 나가기 API를 구현하고 해당하는 통합테스트 코드를 작성함.
* 비지니스 로직에 대해서 생각해볼 부분이 있어 지라티켓으로 남김

<br>

# 코드 리뷰 참고 사항
<!--
ex.
hook 삭제는 v5 버전에 따른 이슈로, 리뷰에서 제외하셔도 됩니다.
member entity이름을 member라고 했는데, member domain도 있고 entity도 있으니,
memberEntity, memberDomain으로 이름을 붙일까하는데 어떄요?
-->
1. Delete Method지만, no content를 보내기에는 응답 message가 필요해서 OK로 처리
2. 관리자의 권한 이전 API가 필요할 것으로 보임. Backlog로 기록 예정

<br>

# 관련 자료
<!--
ex.
notion, jira 등 링크를 포함해서 제공
-->
[Jira](https://hb-wisoft.atlassian.net/browse/WAG-73)
<br>