### PR TITLE
feature/WAG-88/inviteChatroom

### DIFF
--- a/prisma/migrations/20240911133801_delete_profile/migration.sql
+++ b/prisma/migrations/20240911133801_delete_profile/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `profile` on the `member` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "member" DROP COLUMN "profile";

--- a/prisma/migrations/20240921073951_update_profile/migration.sql
+++ b/prisma/migrations/20240921073951_update_profile/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `profile` to the `member` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "member" ADD COLUMN     "profile" VARCHAR(100) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,6 @@ model Member {
   email           String       @unique @db.VarChar(50)
   nickname        String       @unique @db.VarChar(20)
   password        String       @db.VarChar(100)
-  profile         String       @db.VarChar(100)
   managedChatRoom ChatRoom[]
   memberRoom      MemberRoom[]
   files           File[]       @relation("Member")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Member {
   email           String       @unique @db.VarChar(50)
   nickname        String       @unique @db.VarChar(20)
   password        String       @db.VarChar(100)
+  profile         String       @db.VarChar(100)
   managedChatRoom ChatRoom[]
   memberRoom      MemberRoom[]
   files           File[]       @relation("Member")

--- a/src/domain/chat-room/chat-room.controller.ts
+++ b/src/domain/chat-room/chat-room.controller.ts
@@ -38,6 +38,12 @@ import {
 import {
     BigIntPipe,
 } from "./pipe/bigint.pipe";
+import {
+    InviteChatRoomResponseDto,
+} from "./dto/response/invite-chat-room.response.dto";
+import {
+    InviteChatRoomRequestDto,
+} from "./dto/request/invite-chat-room.request.dto";
 
 @ApiTags("ChatRoom")
 @UseGuards(JwtGuard)
@@ -58,12 +64,36 @@ export class ChatRoomController {
     @Post()
     async createChatRoom(@Body() createChatRoomDto: CreateChatRoomRequestDto, @GetMember() member: Member)
         : Promise<CustomResponse<CreateChatRoomResponseDto>> {
-        this.logger.log("[createCharRoom] start");
+        this.logger.log("[createChatRoom] start");
         const result = await this.chatRoomService.createChatRoom(createChatRoomDto, member);
-        this.logger.log("[createCharRoom] finish");
+        this.logger.log("[createChatRoom] finish");
 
         return new CustomResponse<CreateChatRoomResponseDto>(
             ResponseStatus.CHAT_ROOM_S001, result
+        );
+    }
+
+    @ApiOperation({
+        summary: "채팅방 초대 API",
+        description: "회원 ID로 채팅방에 회원을 초대할 수 있다.",
+    })
+    @ApiCustomResponseDecorator(InviteChatRoomResponseDto)
+    @UseGuards(JwtGuard)
+    @HttpCode(HttpStatus.OK)
+    @Post("/:id")
+    async inviteChatRoom(
+        @Param("id", BigIntPipe) chatRoomId: bigint,
+        @Body() body: InviteChatRoomRequestDto,
+        @GetMember() member: Member
+    ): Promise<CustomResponse<InviteChatRoomResponseDto>> {
+        this.logger.log("[inviteChatRoom] start");
+
+        const result = await this.chatRoomService.inviteChatRoom(chatRoomId, body.ids, member.id);
+
+        this.logger.log("[inviteChatRoom] finish");
+
+        return new CustomResponse<InviteChatRoomResponseDto>(
+            ResponseStatus.CHAT_ROOM_S004, result
         );
     }
 

--- a/src/domain/chat-room/chat-room.service.ts
+++ b/src/domain/chat-room/chat-room.service.ts
@@ -236,19 +236,19 @@ export class ChatRoomService {
 
         // 4. 이미 참여 중인 멤버를 필터링
         const existingMembers = chatRoom.MemberRoom.map(mr => mr.memberId);
-        const newMembers = members.filter(member => !existingMembers.includes(member.id));
+        const addMemberIds = members.filter(member => !existingMembers.includes(member.id));
 
-        if(newMembers.length === 0) {
+        if(addMemberIds.length !== members.length) {
             throw new MemberAlreadyJoinedException(ResponseStatus.CHAT_ROOM_F006);
         }
 
         await this.prisma.memberRoom.createMany({
-            data: newMembers.map(member => ({
+            data: addMemberIds.map(member => ({
                 roomId: chatRoomId,
                 memberId: member.id,
             })),
         });
 
-        return new InviteChatRoomResponseDto(`${newMembers.length}명의 회원이 채팅방에 초대되었습니다.`);
+        return new InviteChatRoomResponseDto(`${addMemberIds.length}명의 회원이 채팅방에 초대되었습니다.`);
     }
 }

--- a/src/domain/chat-room/chat-room.service.ts
+++ b/src/domain/chat-room/chat-room.service.ts
@@ -34,6 +34,16 @@ import {
 import {
     LeaveChatRoomFailException,
 } from "../../exception/leave-chat-room-fail.exception";
+import {
+    InviteChatRoomResponseDto,
+} from "./dto/response/invite-chat-room.response.dto";
+import MemberNotExistException from "../../exception/member-not-exist.exception";
+import {
+    MemberAlreadyJoinedException,
+} from "../../exception/member-already-joined.exception";
+import {
+    NoPermissionInviteException,
+} from "../../exception/no-permission-invite.exception";
 
 type ChatRoom = {
     id: bigint | string,
@@ -186,4 +196,59 @@ export class ChatRoomService {
         }
     }
 
+    async inviteChatRoom(
+        chatRoomId: bigint,
+        ids: string[],
+        inviterId: bigint,
+    ): Promise<InviteChatRoomResponseDto> {
+        // 1. 채팅방 존재 여부 확인
+        const chatRoom = await this.prisma.chatRoom.findUnique({
+            where: {
+                id: chatRoomId,
+            },
+            include: {
+                MemberRoom: true,
+            },
+        });
+
+        if (!chatRoom) {
+            throw new ChatRoomNotFoundException(ResponseStatus.CHAT_ROOM_F003);
+        }
+
+        // 2. 초대자가 채팅방의 멤버인지 확인
+        const isInviterMember = chatRoom.MemberRoom.some(mr => mr.memberId === inviterId);
+        if (!isInviterMember) {
+            throw new NoPermissionInviteException(ResponseStatus.CHAT_ROOM_F007);
+        }
+
+        // 3. 초대할 멤버 조회
+        const members = await this.prisma.member.findMany({
+            where: {
+                id: {
+                    in: ids.map(id => BigInt(id)),
+                },
+            },
+        });
+
+        if(members.length !== ids.length) {
+            throw new MemberNotExistException();
+        }
+
+        // 4. 이미 참여 중인 멤버를 필터링
+        const existingMembers = chatRoom.MemberRoom.map(mr => mr.memberId);
+        const newMembers = members.filter(member => !existingMembers.includes(member.id));
+
+        if(newMembers.length === 0) {
+            throw new MemberAlreadyJoinedException(ResponseStatus.CHAT_ROOM_F006);
+        }
+
+        await this.prisma.memberRoom.createMany({
+            data: newMembers.map(member => ({
+                roomId: chatRoomId,
+                memberId: member.id,
+            })),
+        });
+
+        return new InviteChatRoomResponseDto(`${newMembers.length}명의 회원이 채팅방에 초대되었습니다.`);
+    }
 }

--- a/src/domain/chat-room/dto/request/invite-chat-room.request.dto.ts
+++ b/src/domain/chat-room/dto/request/invite-chat-room.request.dto.ts
@@ -1,0 +1,25 @@
+import {
+    ApiProperty,
+} from "@nestjs/swagger";
+import {
+    IsArray, IsString,
+} from "class-validator";
+
+export class InviteChatRoomRequestDto {
+    @ApiProperty({
+        description: "참여할 멤버 ID 배열",
+        example: [
+            "3",
+            "2",
+            "4",
+            "6",
+        ],
+        isArray: true,
+        type: String,
+    })
+    @IsArray()
+    @IsString({
+        each: true,
+    })
+    readonly ids: string[];
+}

--- a/src/domain/chat-room/dto/response/invite-chat-room.response.dto.ts
+++ b/src/domain/chat-room/dto/response/invite-chat-room.response.dto.ts
@@ -1,0 +1,15 @@
+import {
+    ApiProperty,
+} from "@nestjs/swagger";
+
+export class InviteChatRoomResponseDto {
+    @ApiProperty({
+        description: "초대 성공 메시지",
+        example: "3명의 회원이 채팅방에 초대되었습니다.",
+    })
+    readonly message: string;
+
+    constructor(message: string) {
+        this.message = message;
+    }
+}

--- a/src/exception/member-already-joined.exception.ts
+++ b/src/exception/member-already-joined.exception.ts
@@ -1,0 +1,12 @@
+import {
+    BadRequestException,
+} from "./http/bad-request.exception";
+import {
+    ResponseStatusType,
+} from "../response/response-status";
+
+export class MemberAlreadyJoinedException extends BadRequestException {
+    constructor(errorCode: ResponseStatusType) {
+        super("Member already in chat room", errorCode);
+    }
+}

--- a/src/exception/no-permission-invite.exception.ts
+++ b/src/exception/no-permission-invite.exception.ts
@@ -1,0 +1,12 @@
+import {
+    ResponseStatusType,
+} from "../response/response-status";
+import {
+    ForbiddenException,
+} from "./http/forbidden.exception";
+
+export class NoPermissionInviteException extends ForbiddenException {
+    constructor(errorCode: ResponseStatusType) {
+        super("You do not have permission to invite members to this chat room.", errorCode);
+    }
+}

--- a/src/response/response-status.ts
+++ b/src/response/response-status.ts
@@ -27,9 +27,12 @@ export const ResponseStatus = {
     CHAT_ROOM_F003: createResponseStatus("CHAT_ROOM_F003", "Not found chatroom"),
     CHAT_ROOM_F004: createResponseStatus("CHAT_ROOM_F004", "Not found member in chatroom"),
     CHAT_ROOM_F005: createResponseStatus("CHAT_ROOM_F005", "Manager doesn't leave chatroom until only one left"),
+    CHAT_ROOM_F006: createResponseStatus("CHAT_ROOM_F006", "Member already in chat room"),
+    CHAT_ROOM_F007: createResponseStatus("CHAT_ROOM_F007", "No permission to invite members to the chat room"),
     CHAT_ROOM_S001: createResponseStatus("CHAT_ROOM_S001", "POST /chat-rooms"),
     CHAT_ROOM_S002: createResponseStatus("CHAT_ROOM_S002", "GET /chat-rooms"),
     CHAT_ROOM_S003: createResponseStatus("CHAT_ROOM_S003", "DELETE /chat-rooms"),
+    CHAT_ROOM_S004: createResponseStatus("CHAT_ROOM_S004", "POST /chat-rooms"),
 } as const;
 export type ResponseStatusType = {
     code: string,

--- a/src/response/response-status.ts
+++ b/src/response/response-status.ts
@@ -32,7 +32,7 @@ export const ResponseStatus = {
     CHAT_ROOM_S001: createResponseStatus("CHAT_ROOM_S001", "POST /chat-rooms"),
     CHAT_ROOM_S002: createResponseStatus("CHAT_ROOM_S002", "GET /chat-rooms"),
     CHAT_ROOM_S003: createResponseStatus("CHAT_ROOM_S003", "DELETE /chat-rooms"),
-    CHAT_ROOM_S004: createResponseStatus("CHAT_ROOM_S004", "POST /chat-rooms"),
+    CHAT_ROOM_S004: createResponseStatus("CHAT_ROOM_S004", "POST /chat-rooms/:id"),
 } as const;
 export type ResponseStatusType = {
     code: string,


### PR DESCRIPTION
# 작업 분류
<!--이 PR에서 작업한 항목을 모두 체크 -->
- [x] 기능 추가 (feat)
- [ ] 기능 변경 (update)
- [ ] 버그 수정 (fix)
- [ ] 테스트 코드 작성 (test)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (chore)
- [ ] 기타 사소한 수정 (docs)

<br>

# 작업 내용 요약
### 1. 채팅방 초대 API 구현
채팅방 초대 API 로직은 다음과 같습니다.

1) 채팅방 존재 여부 확인
2) 초대자가 채팅방의 멤버인지 확인
3) 초대할 멤버 조회
4) 이미 참여중인 멤버를 필터링

<br>

### 2. 채팅방 초대 API 에 필요한 요청 DTO
채팅방 초대 요청 시에는 초대 할 멤버 배열만을 필요로 하고 있습니다.

<br>

### 3. NoPermissionInviteException 예외
해당 예외는 초대자가 채팅방의 멤버가 아닐 시, 권한이 없음을 알려줍니다.

<br>

### 4. MemberAlreadyJoinedException 예외
해당 예외는 멤버가 이미 채팅방에 참가했을 시, 이미 참여하고 있음을 알려줍니다.


<br>

# 코드 리뷰 참고 사항
이번 이슈 진행 중 고민이 되는 부분이 있어 기재합니다.

> A라는 멤버가 채팅방을 생성했을 시, B와 C를 초대한 이후 사람을 더 초대하려고 한다.
> A는 B가 이미 들어가 있는 줄 모르고, D와 E와 B 세명을 초대한다.

이런 상황일 경우 현재 응답에서는 에러가 아닌 성공적으로 초대된 멤버의 수를 카운팅 후 메세지로 응답해주고 있습니다.
무튼, 이미 초대된 멤버는 초대가 되지 않고 그 이외의 사람들은 성공적으로 초대가 된 것이기 때문에 에러를 발생시킬 이유가 없다고 판단했습니다.

<img width="910" alt="image" src="https://github.com/user-attachments/assets/ecb868b7-c357-4754-8f69-aec3a5f04d74">


위와 같은 상황이 있을 시 에러를 발생 시켜주는 것이 좋을지 고민입니다.


<br>

# 관련 자료
<!--
ex.
notion, jira 등 링크를 포함해서 제공
-->

<br>